### PR TITLE
Add instructions to configure ansible loggging

### DIFF
--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -82,8 +82,9 @@ Ansible also has built-in support for logging. Add the following lines to your a
 ```
 [defaults] 
 log_path=/path/to/logfile
-Ansible will look in several places for the config file:
 ```
+Ansible will look in several places for the config file:
+
 
 * ansible.cfg in the current directory where you ran ansible-playbook
 * ~/.ansible.cfg


### PR DESCRIPTION
@weiweishi asked about how to know the time taken for completion of playbooks.  Timestamps are added when ansible has logging configured.  I've added instructions about how to configure ansible logging.
